### PR TITLE
Minor improvement regarding creation of Action messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "io.github.thoebert"
-version = "1.0.2"
+version = "1.0.3"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/thoebert/krosbridgecodegen/Writer.kt
+++ b/src/main/kotlin/com/github/thoebert/krosbridgecodegen/Writer.kt
@@ -69,9 +69,11 @@ class Writer(val packagePrefix : String = ""){
     }
 
     fun writeAction(folder: File, it: Action) {
-        writeClass(folder, "${it.name}Goal", it.goal)
-        writeClass(folder, "${it.name}Result", it.result)
-        writeClass(folder, "${it.name}Feedback", it.feedback)
+        val goal = mutableListOf<Field>(Field("actionlib_msgs/GoalID", "goal_id"))
+        goal.addAll(it.goal)
+        writeClass(folder, "${it.name}Goal", goal, messageClassName)
+        writeClass(folder, "${it.name}Result", it.result, messageClassName)
+        writeClass(folder, "${it.name}Feedback", it.feedback, messageClassName)
     }
 
     fun prefixPackage(packageName : String) : String {


### PR DESCRIPTION
Made some small changes to the writeAction function. Actions now inherit the Message class and Action Goals now start with an GoalID property.

My reasoning for these changes is that the the Action Server is implemented using 5 different topics and therefore the action messages should be treated as normal messages in case the user wants to implement the actionlib themselves. As for the GoalID it is a pain to merge classes in JVM languages so it's easier to make it available from the get go in the ActionGoal class.

P:S. This project is quite useful so thanks for making it  :3